### PR TITLE
Use PasteDeploy settings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 TAG = github_traverse:latest
 CONTAINER_NAME = github_traverse_container
 TIME_ZONE = Asia/Tokyo
-SRC = $(wildcard github_traverse/*.py)
+SRC = setup.py $(wildcard github_traverse/*.py)
 
 .PHONY: all build start stop restart clean lint format tags
 
@@ -9,12 +9,13 @@ all: start
 
 build: .build
 
-.build: Dockerfile requirements.txt $(SRC)
+.build: Dockerfile requirements.txt development.ini $(SRC)
 	docker build -t $(TAG) .
 	touch .build
 
 start: build
-	docker run -d --name $(CONTAINER_NAME) -p 6543:6543 -e TZ=$(TIME_ZONE) $(TAG) python github_traverse/__init__.py
+	docker run -d --name $(CONTAINER_NAME) -p 6543:6543 -e TZ=$(TIME_ZONE) $(TAG) \
+		gunicorn --paste development.ini --bind 0.0.0.0:6543
 
 stop:
 	-docker rm -f $(CONTAINER_NAME)

--- a/development.ini
+++ b/development.ini
@@ -1,0 +1,9 @@
+# PasteDeploy settings
+#    Ref: https://pastedeploy.readthedocs.io/en/latest/
+
+[app:main]
+paste.app_factory = github_traverse:main
+
+# Debug settings
+#    Ref: https://docs.pylonsproject.org/projects/pyramid/en/latest/narr/environment.html
+#

--- a/development.ini
+++ b/development.ini
@@ -7,3 +7,8 @@ paste.app_factory = github_traverse:main
 # Debug settings
 #    Ref: https://docs.pylonsproject.org/projects/pyramid/en/latest/narr/environment.html
 #
+
+# This settings is no longer used by Gunicorn CLI.
+# But "server:main" section is required when CLI loads PasteDeploy settings.
+[server:main]
+paste.server_runner = gunicorn.app.pasterapp:paste_server

--- a/github_traverse/__init__.py
+++ b/github_traverse/__init__.py
@@ -23,9 +23,3 @@ def main(global_config=None, **settings):
     # FYI: https://docs.pylonsproject.org/projects/pyramid/en/latest/narr/urldispatch.html#redirecting-to-slash-appended-routes
     config.add_notfound_view(append_slash=True)
     return config.make_wsgi_app()
-
-
-if __name__ == '__main__':
-    app = main()
-    server = make_server('0.0.0.0', 6543, app)
-    server.serve_forever()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 pyramid
+gunicorn

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,8 @@ setup(
     include_package_data=True,
 
     install_requires=[
-        'pyramid'
+        'pyramid',
+        'gunicorn'
     ],
     python_requires='>=3',
 )


### PR DESCRIPTION
In PasteDeploy, wsgiref.simple_server can't be used because it doesn't provide server_factory(FYI: https://pastedeploy.readthedocs.io/en/latest/#defining-factories). Thus, I use Gunicorn.